### PR TITLE
The function st.experimental_rerun has been deprecated in recent vers…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -64,7 +64,7 @@ def handle_chat(prompt, chain):
        st.error(f"Error processing request: {str(e)}")
        return
        
-   st.experimental_rerun()
+   st.rerun()
 
 def display_chat():
    for message in st.session_state.messages:


### PR DESCRIPTION
…ions of Streamlit, causing an AttributeError. This commit replaces the deprecated function with its official successor, st.rerun(), to resolve the error and ensure compatibility with the latest Streamlit versions.